### PR TITLE
Added --net and BTRDB_MONGO_SERVER environment setting to brtdb docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you want to try out BTrDB with zero hassles, you can simply use our docker im
 docker network create mynet
 docker run -d --net mynet --name mongo mongo:3.2
 docker run -it --net mynet -v /my/datadir:/srv -e BTRDB_MONGO_SERVER=mongo.mynet btrdb/release:3.4 makedb
-docker run -d -v /my/datadir:/srv -p 4410:4410 btrdb/release:3.4
+docker run -d --net mynet -v /my/datadir:/srv -p 4410:4410 -e BTRDB_MONGO_SERVER=mongo.mynet btrdb/release:3.4
 ```
 
 ### Installation


### PR DESCRIPTION
The docker run command for brtdb was missing the environment variable point to Mongo and did not specify the docker mynet network